### PR TITLE
add default case when collection path is a regex

### DIFF
--- a/collection_manager/collection_manager/services/CollectionWatcher.py
+++ b/collection_manager/collection_manager/services/CollectionWatcher.py
@@ -124,7 +124,10 @@ class CollectionWatcher:
     def _get_files_at_path(self, path: str) -> List[str]:
         if os.path.isfile(path):
             return [path]
-        return [f for f in glob(path + '/**', recursive=True) if os.path.isfile(f)]
+        elif os.path.isdir(path):
+            return [f for f in glob(path + '/**', recursive=True) if os.path.isfile(f)]
+        else:
+            return [f for f in glob(path, recursive=True) if os.path.isfile(f)]
 
     async def _reload_and_reschedule(self):
         try:


### PR DESCRIPTION
To correct issue 309 see https://issues.apache.org/jira/browse/SDAP-309

Tested on bigdata with HLS dataset.
