### PR TITLE
SDAP-310: Added standard_name to nexus tile and solr doc

### DIFF
--- a/granule_ingester/granule_ingester/processors/TileSummarizingProcessor.py
+++ b/granule_ingester/granule_ingester/processors/TileSummarizingProcessor.py
@@ -41,7 +41,7 @@ class TileSummarizingProcessor(TileProcessor):
         super().__init__(*args, **kwargs)
         self._dataset_name = dataset_name
 
-    def process(self, tile, *args, **kwargs):
+    def process(self, tile, dataset, *args, **kwargs):
         tile_type = tile.tile.WhichOneof("tile_type")
         tile_data = getattr(tile.tile, tile_type)
 
@@ -80,6 +80,10 @@ class TileSummarizingProcessor(TileProcessor):
             tile_summary.stats.max_time = max_time
         except NoTimeException:
             pass
+
+        standard_name = dataset.variables[tile_summary.data_var_name].attrs.get('standard_name')
+        if standard_name:
+            tile_summary.standard_name = standard_name
 
         tile.summary.CopyFrom(tile_summary)
         return tile

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -103,6 +103,8 @@ class SolrStore(MetadataStore):
         tile_type = tile.tile.WhichOneof("tile_type")
         tile_data = getattr(tile.tile, tile_type)
 
+        var_name = summary.standard_name if summary.standard_name else summary.data_var_name
+
         input_document = {
             'table_s': self.TABLE_NAME,
             'geo': geo,
@@ -111,6 +113,7 @@ class SolrStore(MetadataStore):
             'sectionSpec_s': summary.section_spec,
             'dataset_s': summary.dataset_name,
             'granule_s': granule_file_name,
+            'tile_var_name_s': var_name,
             'tile_min_lon': bbox.lon_min,
             'tile_max_lon': bbox.lon_max,
             'tile_min_lat': bbox.lat_min,
@@ -121,8 +124,7 @@ class SolrStore(MetadataStore):
             'tile_min_val_d': stats.min,
             'tile_max_val_d': stats.max,
             'tile_avg_val_d': stats.mean,
-            'tile_count_i': int(stats.count),
-            'standard_name': summary.standard_name
+            'tile_count_i': int(stats.count)
         }
 
         ecco_tile_id = getattr(tile_data, 'tile', None)

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -111,7 +111,6 @@ class SolrStore(MetadataStore):
             'sectionSpec_s': summary.section_spec,
             'dataset_s': summary.dataset_name,
             'granule_s': granule_file_name,
-            'tile_var_name_s': summary.data_var_name,
             'tile_min_lon': bbox.lon_min,
             'tile_max_lon': bbox.lon_max,
             'tile_min_lat': bbox.lat_min,
@@ -122,7 +121,8 @@ class SolrStore(MetadataStore):
             'tile_min_val_d': stats.min,
             'tile_max_val_d': stats.max,
             'tile_avg_val_d': stats.mean,
-            'tile_count_i': int(stats.count)
+            'tile_count_i': int(stats.count),
+            'standard_name': summary.standard_name
         }
 
         ecco_tile_id = getattr(tile_data, 'tile', None)

--- a/granule_ingester/tests/reading_processors/test_TileSummarizingProcessor.py
+++ b/granule_ingester/tests/reading_processors/test_TileSummarizingProcessor.py
@@ -1,0 +1,44 @@
+import unittest
+from os import path
+
+import xarray as xr
+from granule_ingester.processors import TileSummarizingProcessor
+from granule_ingester.processors.reading_processors.GridReadingProcessor import GridReadingProcessor
+from nexusproto import DataTile_pb2 as nexusproto
+
+
+class TestTileSummarizingProcessor(unittest.TestCase):
+    def test_standard_name_exists(self):
+        """
+        Test that the standard_name attribute exists in a
+        Tile.TileSummary object after being processed with
+        TileSummarizingProcessor
+        """
+        reading_processor = GridReadingProcessor(
+            variable='analysed_sst',
+            latitude='lat',
+            longitude='lon',
+            time='time',
+            tile='tile'
+        )
+        relative_path = '../granules/20050101120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.0.nc'
+        granule_path = path.join(path.dirname(__file__), relative_path)
+        tile_summary = nexusproto.TileSummary()
+        tile_summary.granule = granule_path
+        tile_summary.data_var_name = 'analysed_sst'
+
+        input_tile = nexusproto.NexusTile()
+        input_tile.summary.CopyFrom(tile_summary)
+
+        dims = {
+            'lat': slice(0, 30),
+            'lon': slice(0, 30),
+            'time': slice(0, 1),
+            'tile': slice(10, 11),
+        }
+
+        with xr.open_dataset(granule_path, decode_cf=True) as ds:
+            output_tile = reading_processor._generate_tile(ds, dims, input_tile)
+            tile_summary_processor = TileSummarizingProcessor('test')
+            new_tile = tile_summary_processor.process(tile=output_tile, dataset=ds)
+            assert new_tile.summary.standard_name == 'sea_surface_temperature'

--- a/granule_ingester/tests/writers/test_SolrStore.py
+++ b/granule_ingester/tests/writers/test_SolrStore.py
@@ -12,7 +12,6 @@ class TestSolrStore(unittest.TestCase):
         tile.summary.tile_id = 'test_id'
         tile.summary.dataset_name = 'test_dataset'
         tile.summary.dataset_uuid = 'test_dataset_id'
-        tile.summary.data_var_name = 'test_variable'
         tile.summary.granule = 'test_granule_path'
         tile.summary.section_spec = 'time:0:1,j:0:20,i:200:240'
         tile.summary.bbox.lat_min = -180.1
@@ -25,6 +24,7 @@ class TestSolrStore(unittest.TestCase):
         tile.summary.stats.count = 100
         tile.summary.stats.min_time = 694224000
         tile.summary.stats.max_time = 694310400
+        tile.summary.standard_name = 'sea_surface_temperature'
 
         tile.tile.ecco_tile.depth = 10.5
 
@@ -39,7 +39,6 @@ class TestSolrStore(unittest.TestCase):
         self.assertEqual('test_dataset!test_id', solr_doc['solr_id_s'])
         self.assertEqual('time:0:1,j:0:20,i:200:240', solr_doc['sectionSpec_s'])
         self.assertEqual('test_granule_path', solr_doc['granule_s'])
-        self.assertEqual('test_variable', solr_doc['tile_var_name_s'])
         self.assertAlmostEqual(-90.5, solr_doc['tile_min_lon'])
         self.assertAlmostEqual(90.0, solr_doc['tile_max_lon'])
         self.assertAlmostEqual(-180.1, solr_doc['tile_min_lat'], delta=1E-5)
@@ -51,3 +50,4 @@ class TestSolrStore(unittest.TestCase):
         self.assertAlmostEqual(12.5, solr_doc['tile_avg_val_d'])
         self.assertEqual(100, solr_doc['tile_count_i'])
         self.assertAlmostEqual(10.5, solr_doc['tile_depth'])
+        self.assertEqual('sea_surface_temperature', solr_doc['standard_name'])


### PR DESCRIPTION
[SDAP-310](https://issues.apache.org/jira/browse/SDAP-310)

To support SDAP-310, the standard_name of the data variable needs to be captured in the solr doc so SDAP can return satellite values using the appropriate key. 

I added a `standard_name` field to TileSummary, and added `standard_name` to the solr doc. I removed `data_var_name` from the solr doc (but left that in TileSummary).