### PR TITLE
SDAP-313 ; added --cassandra-keyspace option to main.py 

### DIFF
--- a/granule_ingester/docker/entrypoint.sh
+++ b/granule_ingester/docker/entrypoint.sh
@@ -7,6 +7,7 @@ python /sdap/granule_ingester/main.py \
   $([[ ! -z "$RABBITMQ_QUEUE" ]] && echo --rabbitmq-queue=$RABBITMQ_QUEUE) \
   $([[ ! -z "$CASSANDRA_CONTACT_POINTS" ]] && echo --cassandra-contact-points=$CASSANDRA_CONTACT_POINTS) \
   $([[ ! -z "$CASSANDRA_PORT" ]] && echo --cassandra-port=$CASSANDRA_PORT) \
+  $([[ ! -z "$CASSANDRA_KEYSPACE" ]] && echo --cassandra-keyspace=$CASSANDRA_KEYSPACE) \
   $([[ ! -z "$CASSANDRA_USERNAME" ]] && echo --cassandra-username=$CASSANDRA_USERNAME) \
   $([[ ! -z "$CASSANDRA_PASSWORD" ]] && echo --cassandra-password=$CASSANDRA_PASSWORD) \
   $([[ ! -z "$SOLR_HOST_AND_PORT" ]] && echo --solr-host-and-port=$SOLR_HOST_AND_PORT) \

--- a/granule_ingester/granule_ingester/writers/CassandraStore.py
+++ b/granule_ingester/granule_ingester/writers/CassandraStore.py
@@ -40,11 +40,12 @@ class TileModel(Model):
 
 
 class CassandraStore(DataStore):
-    def __init__(self, contact_points=None, port=9042, username=None, password=None):
+    def __init__(self, contact_points=None, port=9042, keyspace='nexustiles', username=None, password=None):
         self._contact_points = contact_points
         self._username = username
         self._password = password
         self._port = port
+        self._keyspace = keyspace
         self._session = None
 
     async def health_check(self) -> bool:
@@ -69,7 +70,7 @@ class CassandraStore(DataStore):
                           default_retry_policy=RetryPolicy(),
                           auth_provider=auth_provider)
         session = cluster.connect()
-        session.set_keyspace('nexustiles')
+        session.set_keyspace(self._keyspace)
         return session
 
     def connect(self):


### PR DESCRIPTION
SDAP-313
Added --cassandra-keyspace option to main.py (and propagated to CassandraStore.py and entrypoint.sh) in order to be able to specify a different one than the default "nexustiles".