### PR TITLE
bugfix/SDAP-327 New multivariable reading processors missing from granule ingester module

### DIFF
--- a/granule_ingester/granule_ingester/pipeline/Modules.py
+++ b/granule_ingester/granule_ingester/pipeline/Modules.py
@@ -7,7 +7,9 @@ from granule_ingester.processors import (GenerateTileId,
 from granule_ingester.processors.reading_processors import (EccoReadingProcessor,
                                                             GridReadingProcessor,
                                                             SwathReadingProcessor,
-                                                            TimeSeriesReadingProcessor)
+                                                            TimeSeriesReadingProcessor,
+                                                            GridMultiVariableReadingProcessor,
+                                                            SwathMultiVariableReadingProcessor)
 from granule_ingester.slicers import SliceFileByStepSize
 from granule_ingester.granule_loaders import GranuleLoader
 
@@ -17,8 +19,10 @@ modules = {
     "generateTileId": GenerateTileId,
     "ECCO": EccoReadingProcessor,
     "Grid": GridReadingProcessor,
+    "GridMulti": GridMultiVariableReadingProcessor,
     "TimeSeries": TimeSeriesReadingProcessor,
     "Swath": SwathReadingProcessor,
+    "SwathMulti": SwathMultiVariableReadingProcessor,
     "tileSummary": TileSummarizingProcessor,
     "emptyTileFilter": EmptyTileFilter,
     "kelvinToCelsius": KelvinToCelsius,


### PR DESCRIPTION
- need to add new multi variable reading processors to the module so that they can be run from `configmap`