### PR TITLE
SDAP-340:fix:allow null when standard_name is missing

### DIFF
--- a/granule_ingester/granule_ingester/processors/TileSummarizingProcessor.py
+++ b/granule_ingester/granule_ingester/processors/TileSummarizingProcessor.py
@@ -100,11 +100,8 @@ class TileSummarizingProcessor(TileProcessor):
             pass
         logger.debug(f'calc standard_name')
         standard_names = [dataset.variables[k].attrs.get('standard_name')for k in data_var_name]
-        if any([k is None for k in standard_names]):
-            logger.debug(f'one or more of standard_names is None. skipping. {standard_names}')
-        else:
-            logger.debug(f'using standard_names as all are not None: {standard_names}')
-            tile_summary.standard_name = json.dumps(standard_names if len(standard_names) > 1 else standard_names[0])
+        logger.debug(f'using standard_names: {standard_names}')
+        tile_summary.standard_name = json.dumps(standard_names if len(standard_names) > 1 else standard_names[0])
         logger.debug(f'copy tile_summary to tile')
         tile.summary.CopyFrom(tile_summary)
         return tile

--- a/granule_ingester/tests/reading_processors/test_TileSummarizingProcessor.py
+++ b/granule_ingester/tests/reading_processors/test_TileSummarizingProcessor.py
@@ -75,6 +75,7 @@ class TestTileSummarizingProcessor(unittest.TestCase):
             tile_summary_processor = TileSummarizingProcessor('test')
             new_tile = tile_summary_processor.process(tile=output_tile, dataset=ds)
             self.assertEqual('null', new_tile.summary.standard_name, f'wrong new_tile.summary.standard_name')
+            self.assertEqual(None, json.loads(new_tile.summary.standard_name), f'unable to convert new_tile.summary.standard_name from JSON')
             self.assertTrue(abs(new_tile.summary.stats.mean - 0.26137) < 0.001, f'mean value is not close expected: 0.26137. actual: {new_tile.summary.stats.mean}')
 
     def test_hls_multiple_var_01(self):
@@ -106,4 +107,5 @@ class TestTileSummarizingProcessor(unittest.TestCase):
             tile_summary_processor = TileSummarizingProcessor('test')
             new_tile = tile_summary_processor.process(tile=output_tile, dataset=ds)
             self.assertEqual('[null, null, null, null, null, null, null, null, null, null, null]', new_tile.summary.standard_name, f'wrong new_tile.summary.standard_name')
+            self.assertEqual([None for _ in range(11)], json.loads(new_tile.summary.standard_name), f'unable to convert new_tile.summary.standard_name from JSON')
             self.assertTrue(abs(new_tile.summary.stats.mean - 0.26523) < 0.001, f'mean value is not close expected: 0.26523. actual: {new_tile.summary.stats.mean}')

--- a/granule_ingester/tests/reading_processors/test_TileSummarizingProcessor.py
+++ b/granule_ingester/tests/reading_processors/test_TileSummarizingProcessor.py
@@ -74,6 +74,7 @@ class TestTileSummarizingProcessor(unittest.TestCase):
             output_tile = reading_processor._generate_tile(ds, dimensions_to_slices, input_tile)
             tile_summary_processor = TileSummarizingProcessor('test')
             new_tile = tile_summary_processor.process(tile=output_tile, dataset=ds)
+            self.assertEqual('null', new_tile.summary.standard_name, f'wrong new_tile.summary.standard_name')
             self.assertTrue(abs(new_tile.summary.stats.mean - 0.26137) < 0.001, f'mean value is not close expected: 0.26137. actual: {new_tile.summary.stats.mean}')
 
     def test_hls_multiple_var_01(self):
@@ -104,4 +105,5 @@ class TestTileSummarizingProcessor(unittest.TestCase):
             output_tile = reading_processor._generate_tile(ds, dimensions_to_slices, input_tile)
             tile_summary_processor = TileSummarizingProcessor('test')
             new_tile = tile_summary_processor.process(tile=output_tile, dataset=ds)
+            self.assertEqual('[null, null, null, null, null, null, null, null, null, null, null]', new_tile.summary.standard_name, f'wrong new_tile.summary.standard_name')
             self.assertTrue(abs(new_tile.summary.stats.mean - 0.26523) < 0.001, f'mean value is not close expected: 0.26523. actual: {new_tile.summary.stats.mean}')


### PR DESCRIPTION
Closes https://issues.apache.org/jira/browse/SDAP-340
- for multivariable processes, pass `null` when `standard_name` is missing
- updated test case
- if it is single variable data, it will be either `"the name"` or `null` is passed
- if it is multivariable data, it will be either `["name1", "name2", ..., "nameX"]` or `null` values like `["name1",null,"name2",...]`
- they can be converted back to Python object by using `json.loads(...)`.