### PR TITLE
Added standard name field to solr doc

### DIFF
--- a/granule_ingester/granule_ingester/main.py
+++ b/granule_ingester/granule_ingester/main.py
@@ -107,7 +107,7 @@ async def main(loop):
                         default='http://localhost:8983',
                         metavar='HOST:PORT',
                         help='Solr host and port. (Default: http://localhost:8983)')
-    parser.add_argument('--zk_host_and_port',
+    parser.add_argument('--zk-host-and-port',
                         metavar="HOST:PORT")
     
     # ELASTIC

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -105,8 +105,6 @@ class SolrStore(MetadataStore):
         tile_type = tile.tile.WhichOneof("tile_type")
         tile_data = getattr(tile.tile, tile_type)
 
-        var_name = summary.standard_name if summary.standard_name else summary.data_var_name
-
         input_document = {
             'table_s': self.TABLE_NAME,
             'geo': geo,
@@ -115,7 +113,8 @@ class SolrStore(MetadataStore):
             'sectionSpec_s': summary.section_spec,
             'dataset_s': summary.dataset_name,
             'granule_s': granule_file_name,
-            'tile_var_name_s': var_name,
+            'tile_var_name_s': summary.data_var_name,
+            'tile_standard_name_s': summary.standard_name,
             'tile_min_lon': bbox.lon_min,
             'tile_max_lon': bbox.lon_max,
             'tile_min_lat': bbox.lat_min,

--- a/granule_ingester/tests/writers/test_SolrStore.py
+++ b/granule_ingester/tests/writers/test_SolrStore.py
@@ -26,7 +26,7 @@ class TestSolrStore(unittest.TestCase):
         tile.summary.stats.count = 100
         tile.summary.stats.min_time = 694224000
         tile.summary.stats.max_time = 694310400
-        tile.summary.standard_name = 'sea_surface_temperature'
+        tile.summary.standard_name = json.dumps(['sea_surface_temperature'])
 
         tile.tile.ecco_tile.depth = 10.5
 
@@ -41,7 +41,8 @@ class TestSolrStore(unittest.TestCase):
         self.assertEqual('test_dataset!test_id', solr_doc['solr_id_s'])
         self.assertEqual('time:0:1,j:0:20,i:200:240', solr_doc['sectionSpec_s'])
         self.assertEqual('test_granule_path', solr_doc['granule_s'])
-        self.assertEqual('sea_surface_temperature', solr_doc['tile_var_name_s'])
+        self.assertEqual(json.dumps(['test_variable']), solr_doc['tile_var_name_s'])
+        self.assertEqual(json.dumps(['sea_surface_temperature']), solr_doc['tile_standard_name_s'])
         self.assertAlmostEqual(-90.5, solr_doc['tile_min_lon'])
         self.assertAlmostEqual(90.0, solr_doc['tile_max_lon'])
         self.assertAlmostEqual(-180.1, solr_doc['tile_min_lat'], delta=1E-5)
@@ -86,7 +87,7 @@ class TestSolrStore(unittest.TestCase):
         self.assertEqual('test_dataset!test_id', solr_doc['solr_id_s'])
         self.assertEqual('time:0:1,j:0:20,i:200:240', solr_doc['sectionSpec_s'])
         self.assertEqual('test_granule_path', solr_doc['granule_s'])
-        self.assertEqual(['test_variable', 'test_variable_02'], solr_doc['tile_var_name_s'])
+        self.assertEqual(json.dumps(['test_variable', 'test_variable_02']), solr_doc['tile_var_name_s'])
         self.assertAlmostEqual(-90.5, solr_doc['tile_min_lon'])
         self.assertAlmostEqual(90.0, solr_doc['tile_max_lon'])
         self.assertAlmostEqual(-180.1, solr_doc['tile_min_lat'], delta=1E-5)
@@ -112,4 +113,4 @@ class TestSolrStore(unittest.TestCase):
         metadata_store = SolrStore()
         solr_doc = metadata_store._build_solr_doc(tile)
 
-        self.assertEqual(['test_variable', 'test_variable_02'], solr_doc['tile_var_name_s'])
+        self.assertEqual(json.dumps(['test_variable', 'test_variable_02']), solr_doc['tile_var_name_s'])


### PR DESCRIPTION
To support https://github.com/apache/incubator-sdap-nexus/pull/132, I've added the standard name to the solr doc, and the var_name field in the solr doc uses the var name instead of the standard name. In summary, this means the solr doc will now include both standard name and var name. 

I also fixed some failing tests in granule_ingester/tests/writers/test_SolrStore.py