### PR TITLE
SDAP-323: Update summarizing processor and Solr schema to support multiple variables

### DIFF
--- a/granule_ingester/granule_ingester/processors/TileSummarizingProcessor.py
+++ b/granule_ingester/granule_ingester/processors/TileSummarizingProcessor.py
@@ -101,7 +101,7 @@ class TileSummarizingProcessor(TileProcessor):
         logger.debug(f'calc standard_name')
         standard_names = [dataset.variables[k].attrs.get('standard_name')for k in data_var_name]
         logger.debug(f'using standard_names: {standard_names}')
-        tile_summary.standard_name = json.dumps(standard_names if len(standard_names) > 1 else standard_names[0])
+        tile_summary.standard_name = json.dumps(standard_names)
         logger.debug(f'copy tile_summary to tile')
         tile.summary.CopyFrom(tile_summary)
         return tile

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -106,10 +106,9 @@ class SolrStore(MetadataStore):
         tile_data = getattr(tile.tile, tile_type)
 
         var_names = json.loads(summary.data_var_name)
+        standard_names = []
         if summary.standard_name:
             standard_names = json.loads(summary.standard_name)
-        else:
-            standard_names = [None] * len(var_names)
         if not isinstance(var_names, list):
             var_names = [var_names]
         if not isinstance(standard_names, list):

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -137,7 +137,8 @@ class SolrStore(MetadataStore):
         }
 
         for var_name, standard_name in zip(var_names, standard_names):
-            input_document[f'{var_name}.tile_standard_name_s'] = standard_name
+            if standard_name:
+                input_document[f'{var_name}.tile_standard_name_s'] = standard_name
 
         ecco_tile_id = getattr(tile_data, 'tile', None)
         if ecco_tile_id:

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -105,7 +105,11 @@ class SolrStore(MetadataStore):
         tile_type = tile.tile.WhichOneof("tile_type")
         tile_data = getattr(tile.tile, tile_type)
 
-        var_name = summary.standard_name if summary.standard_name else summary.data_var_name
+        var_names = json.loads(summary.data_var_name)
+        if summary.standard_name:
+            standard_names = json.loads(summary.standard_name)
+        else:
+            standard_names = [None] * len(var_names)
 
         input_document = {
             'table_s': self.TABLE_NAME,
@@ -115,7 +119,7 @@ class SolrStore(MetadataStore):
             'sectionSpec_s': summary.section_spec,
             'dataset_s': summary.dataset_name,
             'granule_s': granule_file_name,
-            'tile_var_name_s': var_name,
+            'tile_var_name_ss': var_names,
             'tile_min_lon': bbox.lon_min,
             'tile_max_lon': bbox.lon_max,
             'tile_min_lat': bbox.lat_min,
@@ -128,6 +132,9 @@ class SolrStore(MetadataStore):
             'tile_avg_val_d': stats.mean,
             'tile_count_i': int(stats.count)
         }
+
+        for var_name, standard_name in zip(var_names, standard_names):
+            input_document[f'{var_name}.tile_standard_name_s'] = standard_name
 
         ecco_tile_id = getattr(tile_data, 'tile', None)
         if ecco_tile_id:

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -110,6 +110,10 @@ class SolrStore(MetadataStore):
             standard_names = json.loads(summary.standard_name)
         else:
             standard_names = [None] * len(var_names)
+        if not isinstance(var_names, list):
+            var_names = [var_names]
+        if not isinstance(standard_names, list):
+            standard_names = [standard_names]
 
         input_document = {
             'table_s': self.TABLE_NAME,

--- a/granule_ingester/tests/writers/test_SolrStore.py
+++ b/granule_ingester/tests/writers/test_SolrStore.py
@@ -115,5 +115,5 @@ class TestSolrStore(unittest.TestCase):
 
         assert ['test_variable', 'test_variable_02'] == solr_doc['tile_var_name_ss']
         # Because there was no standard names in the tile summary, those values should be 'None'
-        assert not solr_doc['test_variable.tile_standard_name_s']
-        assert not solr_doc['test_variable_02.tile_standard_name_s']
+        assert 'test_variable.tile_standard_name_s' not in solr_doc
+        assert 'test_variable_02.tile_standard_name_s' not in solr_doc

--- a/granule_ingester/tests/writers/test_SolrStore.py
+++ b/granule_ingester/tests/writers/test_SolrStore.py
@@ -26,7 +26,7 @@ class TestSolrStore(unittest.TestCase):
         tile.summary.stats.count = 100
         tile.summary.stats.min_time = 694224000
         tile.summary.stats.max_time = 694310400
-        tile.summary.standard_name = 'sea_surface_temperature'
+        tile.summary.standard_name = json.dumps(['sea_surface_temperature'])
 
         tile.tile.ecco_tile.depth = 10.5
 
@@ -41,7 +41,8 @@ class TestSolrStore(unittest.TestCase):
         self.assertEqual('test_dataset!test_id', solr_doc['solr_id_s'])
         self.assertEqual('time:0:1,j:0:20,i:200:240', solr_doc['sectionSpec_s'])
         self.assertEqual('test_granule_path', solr_doc['granule_s'])
-        self.assertEqual('sea_surface_temperature', solr_doc['tile_var_name_s'])
+        self.assertEqual(['test_variable'], solr_doc['tile_var_name_ss'])
+        self.assertEqual('sea_surface_temperature', solr_doc['test_variable.tile_standard_name_s'])
         self.assertAlmostEqual(-90.5, solr_doc['tile_min_lon'])
         self.assertAlmostEqual(90.0, solr_doc['tile_max_lon'])
         self.assertAlmostEqual(-180.1, solr_doc['tile_min_lat'], delta=1E-5)
@@ -86,7 +87,7 @@ class TestSolrStore(unittest.TestCase):
         self.assertEqual('test_dataset!test_id', solr_doc['solr_id_s'])
         self.assertEqual('time:0:1,j:0:20,i:200:240', solr_doc['sectionSpec_s'])
         self.assertEqual('test_granule_path', solr_doc['granule_s'])
-        self.assertEqual(['test_variable', 'test_variable_02'], solr_doc['tile_var_name_s'])
+        self.assertEqual(['test_variable', 'test_variable_02'], solr_doc['tile_var_name_ss'])
         self.assertAlmostEqual(-90.5, solr_doc['tile_min_lon'])
         self.assertAlmostEqual(90.0, solr_doc['tile_max_lon'])
         self.assertAlmostEqual(-180.1, solr_doc['tile_min_lat'], delta=1E-5)
@@ -112,4 +113,7 @@ class TestSolrStore(unittest.TestCase):
         metadata_store = SolrStore()
         solr_doc = metadata_store._build_solr_doc(tile)
 
-        self.assertEqual(['test_variable', 'test_variable_02'], solr_doc['tile_var_name_s'])
+        assert ['test_variable', 'test_variable_02'] == solr_doc['tile_var_name_ss']
+        # Because there was no standard names in the tile summary, those values should be 'None'
+        assert not solr_doc['test_variable.tile_standard_name_s']
+        assert not solr_doc['test_variable_02.tile_standard_name_s']

--- a/granule_ingester/tests/writers/test_SolrStore.py
+++ b/granule_ingester/tests/writers/test_SolrStore.py
@@ -13,7 +13,7 @@ class TestSolrStore(unittest.TestCase):
         tile.summary.tile_id = 'test_id'
         tile.summary.dataset_name = 'test_dataset'
         tile.summary.dataset_uuid = 'test_dataset_id'
-        tile.summary.data_var_name = json.dumps(['test_variable'])
+        tile.summary.data_var_name = json.dumps('test_variable')
         tile.summary.granule = 'test_granule_path'
         tile.summary.section_spec = 'time:0:1,j:0:20,i:200:240'
         tile.summary.bbox.lat_min = -180.1
@@ -26,7 +26,7 @@ class TestSolrStore(unittest.TestCase):
         tile.summary.stats.count = 100
         tile.summary.stats.min_time = 694224000
         tile.summary.stats.max_time = 694310400
-        tile.summary.standard_name = json.dumps(['sea_surface_temperature'])
+        tile.summary.standard_name = json.dumps('sea_surface_temperature')
 
         tile.tile.ecco_tile.depth = 10.5
 


### PR DESCRIPTION
Updated the solr doc to support multiple variables. The following changes were made:

1. Updated var name field to a list type
2. Updated var name field to `tile_var_name_ss`
3. Added a new field `{var_name}.tile_standard_name_s` which contains standard name.

For example:

```json
...
  "tile_var_name_ss": [
    "wind_speed",
    "wind_to_direction"
  ],
  "wind_speed.tile_standard_name_s": "wind_speed",

  "wind_to_direction.tile_standard_name_s": "wind_to_direction",
...
```

The variable name and standard name are still stored as json encoded lists OR strings (single vs multi-var), but then are translated to lists in the solr metadata. In the single-var case, the var name field is a list of size 1, in the multi-var case the var name is a list of size N. 

Note: This PR removes the old `tile_var_name_s` field.

~I implemented it such that standard name is `null` in the solr doc when not available in the granule metadata. Any thoughts about whether or not this is the desired behavior?~