### PR TITLE
wip: SDAP-TODO: feat: S3 obj store

### DIFF
--- a/granule_ingester/docker/entrypoint.sh
+++ b/granule_ingester/docker/entrypoint.sh
@@ -7,6 +7,9 @@ python /sdap/granule_ingester/main.py \
   $([[ ! -z "$RABBITMQ_USERNAME" ]] && echo --rabbitmq-username=$RABBITMQ_USERNAME) \
   $([[ ! -z "$RABBITMQ_PASSWORD" ]] && echo --rabbitmq-password=$RABBITMQ_PASSWORD) \
   $([[ ! -z "$RABBITMQ_QUEUE" ]] && echo --rabbitmq-queue=$RABBITMQ_QUEUE) \
+  $([[ ! -z "$DATA_STORE" ]] && echo --data-store=$DATA_STORE) \
+  $([[ ! -z "$OBJ_STORE_BUCKET" ]] && echo --object-store-bucket=$OBJ_STORE_BUCKET) \
+  $([[ ! -z "$OBJ_STORE_REGION" ]] && echo --object-store-region=$OBJ_STORE_REGION) \
   $([[ ! -z "$CASSANDRA_CONTACT_POINTS" ]] && echo --cassandra-contact-points=$CASSANDRA_CONTACT_POINTS) \
   $([[ ! -z "$CASSANDRA_PORT" ]] && echo --cassandra-port=$CASSANDRA_PORT) \
   $([[ ! -z "$CASSANDRA_KEYSPACE" ]] && echo --cassandra-keyspace=$CASSANDRA_KEYSPACE) \

--- a/granule_ingester/granule_ingester/writers/S3ObjectStore.py
+++ b/granule_ingester/granule_ingester/writers/S3ObjectStore.py
@@ -1,0 +1,57 @@
+import logging
+from io import BytesIO
+from uuid import UUID
+
+import boto3
+from granule_ingester.writers.DataStore import DataStore
+from nexusproto import DataTile_pb2 as nexusproto
+from nexusproto.DataTile_pb2 import TileData, NexusTile
+
+logger = logging.getLogger(__name__)
+
+
+class S3ObjectStore(DataStore):
+    """
+    Should be able to use for AWS-S3 and Ceph Object Store
+    """
+
+    def __init__(self, bucket, region, key=None, secret=None, session=None) -> None:
+        super().__init__()
+        self.__bucket = bucket
+        self.__boto3_session = {
+            'region_name': region,
+        }
+        if key is not None:
+            self.__boto3_session['aws_access_key_id'] = key
+        if secret is not None:
+            self.__boto3_session['aws_secret_access_key'] = secret
+        if session is not None:
+            self.__boto3_session['aws_session_token'] = session
+        self.__s3_client = boto3.Session(**self.__boto3_session).client('s3')
+
+    async def health_check(self) -> bool:
+        try:
+            response = self.__s3_client.list_objects_v2(
+                Bucket=self.__bucket,
+                # Delimiter='string',
+                # EncodingType='url',
+                MaxKeys=10,
+                Prefix='string',
+                ContinuationToken='string',
+                FetchOwner=False,
+                # StartAfter='string',
+                # RequestPayer='requester',
+                # ExpectedBucketOwner='string'
+            )
+            # TODO inspect resopnse object
+        except Exception as e:
+            return False
+        return True
+
+    def save_data(self, nexus_tile: NexusTile) -> None:
+        tile_id = str(UUID(str(nexus_tile.summary.tile_id)))
+        logger.debug(f'saving data {tile_id}')
+        serialized_tile_data = TileData.SerializeToString(nexus_tile.tile)
+        logger.debug(f'uploading to object store')
+        self.__s3_client.upload_fileobj(BytesIO(bytearray(serialized_tile_data)), self.__bucket, f'{tile_id}')
+        return

--- a/granule_ingester/granule_ingester/writers/S3ObjectStore.py
+++ b/granule_ingester/granule_ingester/writers/S3ObjectStore.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 import boto3
 from granule_ingester.writers.DataStore import DataStore
-from nexusproto import DataTile_pb2 as nexusproto
 from nexusproto.DataTile_pb2 import TileData, NexusTile
 
 logger = logging.getLogger(__name__)
@@ -30,23 +29,20 @@ class S3ObjectStore(DataStore):
         self.__s3_client = boto3.Session(**self.__boto3_session).client('s3')
 
     async def health_check(self) -> bool:
-        try:
-            response = self.__s3_client.list_objects_v2(
-                Bucket=self.__bucket,
-                # Delimiter='string',
-                # EncodingType='url',
-                MaxKeys=10,
-                Prefix='string',
-                ContinuationToken='string',
-                FetchOwner=False,
-                # StartAfter='string',
-                # RequestPayer='requester',
-                # ExpectedBucketOwner='string'
-            )
-            # TODO inspect resopnse object
-        except Exception as e:
-            return False
-        return True
+        response = self.__s3_client.list_objects_v2(
+            Bucket=self.__bucket,
+            # Delimiter='string',
+            # EncodingType='url',
+            MaxKeys=10,
+            Prefix='',
+            # ContinuationToken='string',
+            FetchOwner=False,
+            # StartAfter='string',
+            # RequestPayer='requester',
+            # ExpectedBucketOwner='string'
+        )
+
+        return response['ResponseMetadata']['HTTPStatusCode'] < 200
 
     def save_data(self, nexus_tile: NexusTile) -> None:
         tile_id = str(UUID(str(nexus_tile.summary.tile_id)))

--- a/granule_ingester/granule_ingester/writers/__init__.py
+++ b/granule_ingester/granule_ingester/writers/__init__.py
@@ -2,3 +2,4 @@ from granule_ingester.writers.DataStore import DataStore
 from granule_ingester.writers.MetadataStore import MetadataStore
 from granule_ingester.writers.SolrStore import SolrStore
 from granule_ingester.writers.CassandraStore import CassandraStore
+from granule_ingester.writers.S3ObjectStore import S3ObjectStore


### PR DESCRIPTION
- add class to store tile blob in S3 in addition to Cassandra
- update configuration to accept either S3 or Cassandra
- refactor main method to avoid code duplication
- TODO: add test case
- TODO: AWS credentials

### How SDAP handles S3 credentials
- 
- Query repo already has S3 class to extract data from S3: https://github.com/apache/incubator-sdap-nexus/blob/master/data-access/nexustiles/dao/S3Proxy.py
- Collection Manager also has a class to observe files in S3 bucket to be ingested: https://github.com/apache/incubator-sdap-ingester/blob/dev/collection_manager/collection_manager/services/S3Observer.py
- Both classes assume AWS credentials are handled at a different place since they don't have code to do so. 
- How are they being handled as we will need that info to write a test case. 