### PR TITLE
SDAP-417: Prevent SolrStore from generating documents with incorrect WKT for spatially small tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed bug where very spatially narrow tiles would have their WKT for the geo field represent the incorrect shape (ie a very narrow polygon being rounded to a line), which would cause an error on write to Solr.
+- SDAP-417: Fixed bug where very spatially narrow tiles would have their WKT for the geo field represent the incorrect shape (ie a very narrow polygon being rounded to a line), which would cause an error on write to Solr.
 ### Security
 
 ## [1.0.0] - 2022-11-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fixed bug where very spatially narrow tiles would have their WKT for the geo field represent the incorrect shape (ie a very narrow polygon being rounded to a line), which would cause an error on write to Solr.
+### Security
+
 ## [1.0.0] - 2022-11-22
 ### Added
 ### Changed

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -243,7 +243,7 @@ class SolrStore(MetadataStore):
                 lat_min_str = cls._format_latlon_string(bbox.lat_min, rounding=-1)
                 lat_max_str = cls._format_latlon_string(bbox.lat_max, rounding=1)
 
-            geo = 'LINESTRING({} {}, {} {})'.format(lon_min_str, lat_min_str, lon_max_str, lat_min_str)
+            geo = 'LINESTRING({} {}, {} {})'.format(lon_min_str, lat_min_str, lon_max_str, lat_max_str)
         # All other cases should use POLYGON
         else:
             # If the rounding makes any min/max coord pairs equal, expand them so the polygon doesn't collapse into a

--- a/granule_ingester/granule_ingester/writers/SolrStore.py
+++ b/granule_ingester/granule_ingester/writers/SolrStore.py
@@ -231,6 +231,14 @@ class SolrStore(MetadataStore):
             geo = 'LINESTRING({} {}, {} {})'.format(lon_min_str, lat_min_str, lon_max_str, lat_min_str)
         # All other cases should use POLYGON
         else:
+            if lon_min_str == lon_max_str:
+                lon_min_str = str(bbox.lon_min)
+                lon_max_str = str(bbox.lon_max)
+
+            if lat_min_str == lat_max_str:
+                lat_min_str = str(bbox.lat_min)
+                lat_max_str = str(bbox.lat_max)
+
             geo = 'POLYGON(({} {}, {} {}, {} {}, {} {}, {} {}))'.format(lon_min_str, lat_min_str,
                                                                         lon_max_str, lat_min_str,
                                                                         lon_max_str, lat_max_str,


### PR DESCRIPTION
For narrow tiles (max/min lat/lon difference ~<0.001) the generated WKT for the geo field for the Solr document would essentially collapse to a lower dimensional shape while being described as a higher dimensional shape (ie a POLYGON that was a line or a LINESTRING that was a point). Solr would throw an error when trying to write such documents, which has been observed occurring when ingesting granules for the VIIRS_NPP-JPL-L2P-v2016.2 dataset.

To fix this, we now check to see if the collapse will occur (if the bbox values differ but the string representations don't) and then force the string representations of the max/min values to have at least a 0.001 difference.

This has been tested successfully with a granule that previously caused this issue.