### PR TITLE
SDAP-435 + SDAP-437 - Granule preprocessing and timedelta array support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - SDAP-423: Fixed verbosity settings not propagating to ingester subprocesses
 - SDAP-417: Fixed bug where very spatially narrow tiles would have their WKT for the geo field represent the incorrect shape (ie a very narrow polygon being rounded to a line), which would cause an error on write to Solr.
+- SDAP-435: Added case for handling time arrays of type `np.timedelta64`
 ### Security
 
 ## [1.0.0] - 2022-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- SDAP-437: Added support for preprocessing of input granules. Initial implementation contains one preprocessor implementation for squeezing one or more dimensions to ensure the dataset is shaped as needed.
 ### Changed
 ### Deprecated
 ### Removed

--- a/collection_manager/collection_manager/entities/Collection.py
+++ b/collection_manager/collection_manager/entities/Collection.py
@@ -47,6 +47,7 @@ class Collection:
     forward_processing_priority: Optional[int] = None
     date_from: Optional[datetime] = None
     date_to: Optional[datetime] = None
+    squeeze: Optional[frozenset] = None
 
     @staticmethod
     def __decode_dimension_names(dimension_names_dict):
@@ -79,6 +80,14 @@ class Collection:
             date_to = datetime.fromisoformat(properties['to']) if 'to' in properties else None
             date_from = datetime.fromisoformat(properties['from']) if 'from' in properties else None
 
+            if 'squeeze' in properties:
+                if type(properties['squeeze']) == list:
+                    squeeze = frozenset(properties['squeeze'])
+                else:
+                    squeeze = frozenset([properties['squeeze']])
+            else:
+                squeeze = None
+
             collection = Collection(dataset_id=properties['id'],
                                     projection=properties['projection'],
                                     dimension_names=frozenset(Collection.__decode_dimension_names(properties['dimensionNames'])),
@@ -87,7 +96,8 @@ class Collection:
                                     historical_priority=properties['priority'],
                                     forward_processing_priority=properties.get('forward-processing-priority', None),
                                     date_to=date_to,
-                                    date_from=date_from)
+                                    date_from=date_from,
+                                    squeeze=squeeze)
             return collection
         except KeyError as e:
             raise MissingValueCollectionError(missing_value=e.args[0])

--- a/collection_manager/collection_manager/entities/Collection.py
+++ b/collection_manager/collection_manager/entities/Collection.py
@@ -48,6 +48,7 @@ class Collection:
     date_from: Optional[datetime] = None
     date_to: Optional[datetime] = None
     squeeze: Optional[frozenset] = None
+    preprocess: str = None
 
     @staticmethod
     def __decode_dimension_names(dimension_names_dict):
@@ -88,6 +89,8 @@ class Collection:
             else:
                 squeeze = None
 
+            preprocess = json.dumps(properties['preprocess']) if 'preprocess' in properties else None
+
             collection = Collection(dataset_id=properties['id'],
                                     projection=properties['projection'],
                                     dimension_names=frozenset(Collection.__decode_dimension_names(properties['dimensionNames'])),
@@ -97,7 +100,8 @@ class Collection:
                                     forward_processing_priority=properties.get('forward-processing-priority', None),
                                     date_to=date_to,
                                     date_from=date_from,
-                                    squeeze=squeeze)
+                                    squeeze=squeeze,
+                                    preprocess=preprocess)
             return collection
         except KeyError as e:
             raise MissingValueCollectionError(missing_value=e.args[0])

--- a/collection_manager/collection_manager/entities/Collection.py
+++ b/collection_manager/collection_manager/entities/Collection.py
@@ -21,8 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from fnmatch import fnmatch
-from glob import glob
-from typing import List, Optional
+from typing import Optional
 from urllib.parse import urlparse
 
 from collection_manager.entities.exceptions import MissingValueCollectionError
@@ -47,7 +46,6 @@ class Collection:
     forward_processing_priority: Optional[int] = None
     date_from: Optional[datetime] = None
     date_to: Optional[datetime] = None
-    squeeze: Optional[frozenset] = None
     preprocess: str = None
 
     @staticmethod
@@ -81,14 +79,6 @@ class Collection:
             date_to = datetime.fromisoformat(properties['to']) if 'to' in properties else None
             date_from = datetime.fromisoformat(properties['from']) if 'from' in properties else None
 
-            if 'squeeze' in properties:
-                if type(properties['squeeze']) == list:
-                    squeeze = frozenset(properties['squeeze'])
-                else:
-                    squeeze = frozenset([properties['squeeze']])
-            else:
-                squeeze = None
-
             preprocess = json.dumps(properties['preprocess']) if 'preprocess' in properties else None
 
             collection = Collection(dataset_id=properties['id'],
@@ -100,7 +90,6 @@ class Collection:
                                     forward_processing_priority=properties.get('forward-processing-priority', None),
                                     date_to=date_to,
                                     date_from=date_from,
-                                    squeeze=squeeze,
                                     preprocess=preprocess)
             return collection
         except KeyError as e:

--- a/collection_manager/collection_manager/services/CollectionProcessor.py
+++ b/collection_manager/collection_manager/services/CollectionProcessor.py
@@ -122,6 +122,10 @@ class CollectionProcessor:
             },
             'processors': CollectionProcessor._get_default_processors(collection)
         }
+
+        if collection.squeeze is not None:
+            config_dict['squeeze'] = list(collection.squeeze)
+
         config_str = yaml.dump(config_dict)
         logger.debug(f"Templated dataset config:\n{config_str}")
         return config_str

--- a/collection_manager/collection_manager/services/CollectionProcessor.py
+++ b/collection_manager/collection_manager/services/CollectionProcessor.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+import json
 import os.path
 from glob import glob
 from typing import Dict
@@ -125,6 +126,9 @@ class CollectionProcessor:
 
         if collection.squeeze is not None:
             config_dict['squeeze'] = list(collection.squeeze)
+
+        if collection.preprocess is not None:
+            config_dict['preprocess'] = json.loads(collection.preprocess)
 
         config_str = yaml.dump(config_dict)
         logger.debug(f"Templated dataset config:\n{config_str}")

--- a/collection_manager/collection_manager/services/CollectionProcessor.py
+++ b/collection_manager/collection_manager/services/CollectionProcessor.py
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import json
+import logging
 import os.path
-from glob import glob
 from typing import Dict
-from datetime import datetime
 
 import yaml
 from collection_manager.entities import Collection
@@ -123,9 +121,6 @@ class CollectionProcessor:
             },
             'processors': CollectionProcessor._get_default_processors(collection)
         }
-
-        if collection.squeeze is not None:
-            config_dict['squeeze'] = list(collection.squeeze)
 
         if collection.preprocess is not None:
             config_dict['preprocess'] = json.loads(collection.preprocess)

--- a/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
+++ b/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
@@ -20,7 +20,6 @@ from urllib import parse
 
 import aioboto3
 import xarray as xr
-
 from granule_ingester.exceptions import GranuleLoadingError, PipelineBuildingError
 from granule_ingester.granule_loaders.Preprocessors import modules as module_mappings
 from granule_ingester.preprocessors import GranulePreprocessor
@@ -31,11 +30,8 @@ logger = logging.getLogger(__name__)
 class GranuleLoader:
 
     def __init__(self, resource: str, *args, **kwargs):
-        # super().__init__(*args, **kwargs)
-
         self._granule_temp_file = None
         self._resource = resource
-        self._squeeze_dims = kwargs.get('squeeze', None)
         self._preprocess = None
 
         if 'preprocess' in kwargs:
@@ -72,12 +68,6 @@ class GranuleLoader:
                     ds = preprocessor.process(ds)
 
             return ds, granule_name
-
-            # if self._squeeze_dims is None:
-            #     return ds, granule_name
-            # else:
-            #     logger.debug(f'Squeezing dims: {self._squeeze_dims}')
-            #     return ds.squeeze(self._squeeze_dims), granule_name
         except FileNotFoundError:
             raise GranuleLoadingError(f"The granule file {self._resource} does not exist.")
         except Exception:

--- a/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
+++ b/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
@@ -61,7 +61,7 @@ class GranuleLoader:
             ds = xr.open_dataset(file_path, lock=False)
 
             if self._preprocess is not None:
-                logger.debug(f'There are {len(self._preprocess)} preprocessors to run')
+                logger.info(f'There are {len(self._preprocess)} preprocessors to apply for granule {self._resource}')
                 while len(self._preprocess) > 0:
                     preprocessor: GranulePreprocessor = self._preprocess.pop(0)
 

--- a/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
+++ b/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
@@ -21,7 +21,9 @@ from urllib import parse
 import aioboto3
 import xarray as xr
 
-from granule_ingester.exceptions import GranuleLoadingError
+from granule_ingester.exceptions import GranuleLoadingError, PipelineBuildingError
+from granule_ingester.granule_loaders.Preprocessors import modules as module_mappings
+from granule_ingester.preprocessors import GranulePreprocessor
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,10 @@ class GranuleLoader:
         self._granule_temp_file = None
         self._resource = resource
         self._squeeze_dims = kwargs.get('squeeze', None)
+        self._preprocess = None
+
+        if 'preprocess' in kwargs:
+            self._preprocess = [GranuleLoader._parse_module(module) for module in kwargs['preprocess']]
 
     async def __aenter__(self):
         return await self.open()
@@ -57,11 +63,21 @@ class GranuleLoader:
         granule_name = os.path.basename(self._resource)
         try:
             ds = xr.open_dataset(file_path, lock=False)
-            if self._squeeze_dims is None:
-                return ds, granule_name
-            else:
-                logger.debug(f'Squeezing dims: {self._squeeze_dims}')
-                return ds.squeeze(self._squeeze_dims), granule_name
+
+            if self._preprocess is not None:
+                logger.debug(f'There are {len(self._preprocess)} preprocessors to run')
+                while len(self._preprocess) > 0:
+                    preprocessor: GranulePreprocessor = self._preprocess.pop(0)
+
+                    ds = preprocessor.process(ds)
+
+            return ds, granule_name
+
+            # if self._squeeze_dims is None:
+            #     return ds, granule_name
+            # else:
+            #     logger.debug(f'Squeezing dims: {self._squeeze_dims}')
+            #     return ds.squeeze(self._squeeze_dims), granule_name
         except FileNotFoundError:
             raise GranuleLoadingError(f"The granule file {self._resource} does not exist.")
         except Exception:
@@ -82,3 +98,18 @@ class GranuleLoader:
         fp.write(data)
         logger.info("Saved downloaded file to {}.".format(fp.name))
         return fp
+
+    @staticmethod
+    def _parse_module(module_config: dict):
+        module_name = module_config.pop('name')
+        try:
+            module_class = module_mappings[module_name]
+            logger.debug("Loaded preprocessor {}.".format(module_class))
+            processor_module = module_class(**module_config)
+        except KeyError:
+            raise PipelineBuildingError(f"'{module_name}' is not a valid preprocessor.")
+        except Exception as e:
+            raise PipelineBuildingError(f"Parsing module '{module_name}' failed because of the following error: {e}")
+
+        return processor_module
+

--- a/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
+++ b/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Type
+
+from granule_ingester.preprocessors import (GranulePreprocessor)
+
+
+modules: Dict[str, Type[GranulePreprocessor]] = {
+    'squeeze': GranulePreprocessor
+}

--- a/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
+++ b/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
@@ -17,7 +17,6 @@ from typing import Dict, Type
 
 from granule_ingester.preprocessors import (GranulePreprocessor, Squeeze)
 
-
 modules: Dict[str, Type[GranulePreprocessor]] = {
     'squeeze': Squeeze
 }

--- a/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
+++ b/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
@@ -15,9 +15,9 @@
 
 from typing import Dict, Type
 
-from granule_ingester.preprocessors import (GranulePreprocessor)
+from granule_ingester.preprocessors import (GranulePreprocessor, Squeeze)
 
 
 modules: Dict[str, Type[GranulePreprocessor]] = {
-    'squeeze': GranulePreprocessor
+    'squeeze': Squeeze
 }

--- a/granule_ingester/granule_ingester/pipeline/Pipeline.py
+++ b/granule_ingester/granule_ingester/pipeline/Pipeline.py
@@ -69,7 +69,7 @@ def _init_worker(processor_list, dataset, data_store_factory, metadata_store_fac
 
 async def _process_tile_in_worker(serialized_input_tile: str):
     try:
-        logger.info('Starting tile creation subprocess')
+        logger.debug('Starting tile creation subprocess')
         logger.debug(f'serialized_input_tile: {serialized_input_tile}')
         input_tile = nexusproto.NexusTile.FromString(serialized_input_tile)
         logger.info(f'Creating tile for slice {input_tile.summary.section_spec}')
@@ -79,11 +79,11 @@ async def _process_tile_in_worker(serialized_input_tile: str):
             logger.info('Processed tile is empty; adding None result to return')
             return None
 
-        logger.info('Tile processing complete; serializing output tile')
+        logger.debug('Tile processing complete; serializing output tile')
 
         serialized_output_tile = nexusproto.NexusTile.SerializeToString(processed_tile)
 
-        logger.info('Adding serialized result to return')
+        logger.debug('Adding serialized result to return')
 
         return serialized_output_tile
     except Exception as e:

--- a/granule_ingester/granule_ingester/pipeline/Pipeline.py
+++ b/granule_ingester/granule_ingester/pipeline/Pipeline.py
@@ -171,7 +171,10 @@ class Pipeline:
                         module_mappings: dict,
                         max_concurrency: int):
         try:
-            granule_loader = GranuleLoader(**config['granule'])
+            if 'squeeze' in config:
+                granule_loader = GranuleLoader(**config['granule'], **{'squeeze': config['squeeze']})
+            else:
+                granule_loader = GranuleLoader(**config['granule'])
 
             slicer_config = config['slicer']
             slicer = cls._parse_module(slicer_config, module_mappings)

--- a/granule_ingester/granule_ingester/pipeline/Pipeline.py
+++ b/granule_ingester/granule_ingester/pipeline/Pipeline.py
@@ -16,7 +16,6 @@
 import logging
 import pickle
 import time
-import json
 from multiprocessing import Manager
 from typing import List
 
@@ -174,8 +173,6 @@ class Pipeline:
         try:
             if 'preprocess' in config:
                 granule_loader = GranuleLoader(**config['granule'], **{'preprocess': config['preprocess']})
-            elif 'squeeze' in config:
-                granule_loader = GranuleLoader(**config['granule'], **{'squeeze': config['squeeze']})
             else:
                 granule_loader = GranuleLoader(**config['granule'])
 

--- a/granule_ingester/granule_ingester/pipeline/Pipeline.py
+++ b/granule_ingester/granule_ingester/pipeline/Pipeline.py
@@ -16,6 +16,7 @@
 import logging
 import pickle
 import time
+import json
 from multiprocessing import Manager
 from typing import List
 
@@ -171,7 +172,9 @@ class Pipeline:
                         module_mappings: dict,
                         max_concurrency: int):
         try:
-            if 'squeeze' in config:
+            if 'preprocess' in config:
+                granule_loader = GranuleLoader(**config['granule'], **{'preprocess': config['preprocess']})
+            elif 'squeeze' in config:
                 granule_loader = GranuleLoader(**config['granule'], **{'squeeze': config['squeeze']})
             else:
                 granule_loader = GranuleLoader(**config['granule'])

--- a/granule_ingester/granule_ingester/preprocessors/GranulePreprocessor.py
+++ b/granule_ingester/granule_ingester/preprocessors/GranulePreprocessor.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+
 import xarray as xr
 
 

--- a/granule_ingester/granule_ingester/preprocessors/GranulePreprocessor.py
+++ b/granule_ingester/granule_ingester/preprocessors/GranulePreprocessor.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+import xarray as xr
+
+
+class GranulePreprocessor(ABC):
+    @abstractmethod
+    def process(self, input_dataset: xr.Dataset, *args, **kwargs):
+        pass

--- a/granule_ingester/granule_ingester/preprocessors/Squeeze.py
+++ b/granule_ingester/granule_ingester/preprocessors/Squeeze.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import xarray as xr
 import logging
+
+import xarray as xr
 from granule_ingester.preprocessors.GranulePreprocessor import GranulePreprocessor
 
 logger = logging.getLogger(__name__)

--- a/granule_ingester/granule_ingester/preprocessors/Squeeze.py
+++ b/granule_ingester/granule_ingester/preprocessors/Squeeze.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 import xarray as xr
+import logging
 from granule_ingester.preprocessors.GranulePreprocessor import GranulePreprocessor
+
+logger = logging.getLogger(__name__)
 
 
 class Squeeze(GranulePreprocessor):
@@ -22,4 +25,7 @@ class Squeeze(GranulePreprocessor):
         self._dimensions = dimensions
 
     def process(self, input_dataset: xr.Dataset, *args, **kwargs):
-        return input_dataset.squeeze(self._dimensions)
+        logger.debug(f'Squeezing dimensions {self._dimensions}')
+        output_ds = input_dataset.squeeze(self._dimensions)
+        logger.debug(f'Squeezed dimensions: {input_dataset.dims} -> {output_ds.dims}')
+        return output_ds

--- a/granule_ingester/granule_ingester/preprocessors/Squeeze.py
+++ b/granule_ingester/granule_ingester/preprocessors/Squeeze.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import xarray as xr
+from granule_ingester.preprocessors.GranulePreprocessor import GranulePreprocessor
+
+
+class Squeeze(GranulePreprocessor):
+    def __init__(self, dimensions: list):
+        self._dimensions = dimensions
+
+    def process(self, input_dataset: xr.Dataset, *args, **kwargs):
+        return input_dataset.squeeze(self._dimensions)

--- a/granule_ingester/granule_ingester/preprocessors/__init__.py
+++ b/granule_ingester/granule_ingester/preprocessors/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from granule_ingester.preprocessors.GranulePreprocessor import GranulePreprocessor
+from granule_ingester.preprocessors.Squeeze import Squeeze
+

--- a/granule_ingester/granule_ingester/processors/reading_processors/TileReadingProcessor.py
+++ b/granule_ingester/granule_ingester/processors/reading_processors/TileReadingProcessor.py
@@ -20,10 +20,9 @@ from typing import Dict, Union
 
 import numpy as np
 import xarray as xr
-from nexusproto import DataTile_pb2 as nexusproto
-
 from granule_ingester.exceptions import TileProcessingError
 from granule_ingester.processors.TileProcessor import TileProcessor
+from nexusproto import DataTile_pb2 as nexusproto
 
 logger = logging.getLogger(__name__)
 

--- a/granule_ingester/granule_ingester/processors/reading_processors/TileReadingProcessor.py
+++ b/granule_ingester/granule_ingester/processors/reading_processors/TileReadingProcessor.py
@@ -53,6 +53,7 @@ class TileReadingProcessor(TileProcessor, ABC):
 
             return self._generate_tile(dataset, dimensions_to_slices, output_tile)
         except Exception as e:
+            logger.exception(e)
             raise TileProcessingError(f"Could not generate tiles from the granule because of the following error: {e}.")
 
     @abstractmethod
@@ -86,5 +87,12 @@ class TileReadingProcessor(TileProcessor, ABC):
     def _convert_to_timestamp(times: xr.DataArray) -> xr.DataArray:
         if times.dtype == np.float32:
             return times
+        elif times.dtype.type == np.timedelta64:    # If time is an array of offsets from a fixed reference
+            reference = times.time.item() / 1e9     # Get the base time in seconds
+
+            times = (times / 1e9).astype(int)       # Convert offset array to seconds
+            times = times.where(times != -9223372036854775808)  # Replace NaT values with NaN
+
+            return times + reference    # Add base to offsets
         epoch = np.datetime64(datetime.datetime(1970, 1, 1, 0, 0, 0))
         return ((times - epoch) / 1e9).astype(int)


### PR DESCRIPTION
Fixes for errors found when working with [VIIRS data](https://podaac.jpl.nasa.gov/dataset/VIIRS_NPP-JPL-L2P-v2016.2?ids=&values=&search=VIIRS_NPP-JPL-L2P-v2016.2&provider=POCLOUD).

SDAP-435:
The VIIRS granules don't have a direct time array, rather, they have a fixed reference time and an array of offsets in seconds from that time. This translates to an array of `np.timedelta64` type when we currently expect either `np.float32` or `np.datetime64`. Added a case for `np.timedelta64` that adds the reference time to the offset time for a proper int array of timestamps.

SDAP-437:
The VIIRS granules have an extra single-element dimension for time (it seems to correspond to the time reference). This results in the generated tiles having an extra dimension too. My fix for this involves allowing a dimension to squeeze to be specified in the collection config which is then passed to the granule ingester. This is then applied to the granule `xr.Dataset` before slices are generated.