### PR TITLE
SDAP-477 + SDAP-478 - 1D preprocessor + subgroup selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- SDAP-477: Added preprocessor to properly shape incoming data
+- SDAP-478: Add support to user to select subgroup of interest in input granules
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [1.1.0] - 2023-04-26
 ### Added
 - SDAP-437: Added support for preprocessing of input granules. Initial implementation contains one preprocessor implementation for squeezing one or more dimensions to ensure the dataset is shaped as needed.

--- a/collection_manager/collection_manager/entities/Collection.py
+++ b/collection_manager/collection_manager/entities/Collection.py
@@ -47,6 +47,8 @@ class Collection:
     date_from: Optional[datetime] = None
     date_to: Optional[datetime] = None
     preprocess: str = None
+    processors: str = None
+    group: str = None
 
     @staticmethod
     def __decode_dimension_names(dimension_names_dict):
@@ -80,6 +82,7 @@ class Collection:
             date_from = datetime.fromisoformat(properties['from']) if 'from' in properties else None
 
             preprocess = json.dumps(properties['preprocess']) if 'preprocess' in properties else None
+            extra_processors = json.dumps(properties['processors']) if 'processors' in properties else None
 
             collection = Collection(dataset_id=properties['id'],
                                     projection=properties['projection'],
@@ -90,7 +93,9 @@ class Collection:
                                     forward_processing_priority=properties.get('forward-processing-priority', None),
                                     date_to=date_to,
                                     date_from=date_from,
-                                    preprocess=preprocess)
+                                    preprocess=preprocess,
+                                    processors=extra_processors,
+                                    group=properties.get('group'))
             return collection
         except KeyError as e:
             raise MissingValueCollectionError(missing_value=e.args[0])

--- a/collection_manager/collection_manager/services/CollectionProcessor.py
+++ b/collection_manager/collection_manager/services/CollectionProcessor.py
@@ -125,6 +125,12 @@ class CollectionProcessor:
         if collection.preprocess is not None:
             config_dict['preprocess'] = json.loads(collection.preprocess)
 
+        if collection.processors is not None:
+            config_dict['processors'].extend(json.loads(collection.processors))
+
+        if collection.group is not None:
+            config_dict['granule']['group'] = collection.group
+
         config_str = yaml.dump(config_dict)
         logger.debug(f"Templated dataset config:\n{config_str}")
         return config_str

--- a/granule_ingester/conda-requirements.txt
+++ b/granule_ingester/conda-requirements.txt
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-numpy==1.15.4
+numpy>=1.15.4
 scipy
 netcdf4==1.5.3
-pandas==1.0.4
+pandas>=1.0.4
 pytz==2019.3
-xarray
+xarray>=0.19.0
 pyyaml==5.3.1
 aiohttp==3.6.2
 tenacity

--- a/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
+++ b/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
@@ -34,6 +34,11 @@ class GranuleLoader:
         self._resource = resource
         self._preprocess = None
 
+        if 'group' in kwargs:
+            self._group = kwargs['group']
+        else:
+            self._group = None
+
         if 'preprocess' in kwargs:
             self._preprocess = [GranuleLoader._parse_module(module) for module in kwargs['preprocess']]
 
@@ -58,7 +63,12 @@ class GranuleLoader:
 
         granule_name = os.path.basename(self._resource)
         try:
-            ds = xr.open_dataset(file_path, lock=False)
+            additional_params = {}
+
+            if self._group is not None:
+                additional_params['group'] = self._group
+
+            ds = xr.open_dataset(file_path, lock=False, **additional_params)
 
             if self._preprocess is not None:
                 logger.info(f'There are {len(self._preprocess)} preprocessors to apply for granule {self._resource}')

--- a/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
+++ b/granule_ingester/granule_ingester/granule_loaders/Preprocessors.py
@@ -15,8 +15,13 @@
 
 from typing import Dict, Type
 
-from granule_ingester.preprocessors import (GranulePreprocessor, Squeeze)
+from granule_ingester.preprocessors import (
+    GranulePreprocessor,
+    Squeeze,
+    Trajectory
+)
 
 modules: Dict[str, Type[GranulePreprocessor]] = {
-    'squeeze': Squeeze
+    'squeeze': Squeeze,
+    'trajectory': Trajectory
 }

--- a/granule_ingester/granule_ingester/preprocessors/Trajectory.py
+++ b/granule_ingester/granule_ingester/preprocessors/Trajectory.py
@@ -13,7 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from granule_ingester.preprocessors.GranulePreprocessor import GranulePreprocessor
-from granule_ingester.preprocessors.Squeeze import Squeeze
-from granule_ingester.preprocessors.Trajectory import Trajectory
+import logging
 
+import xarray as xr
+from granule_ingester.preprocessors.GranulePreprocessor import GranulePreprocessor
+from math import sqrt, ceil
+
+logger = logging.getLogger(__name__)
+
+
+class Trajectory(GranulePreprocessor):
+    def __init__(self, dimension: str):
+        self._dim = dimension
+
+    def process(self, input_dataset: xr.Dataset, *args, **kwargs):
+        length = len(input_dataset[self._dim])
+        window = ceil(sqrt(length))
+
+        return input_dataset.coarsen(**{self._dim: window}, boundary='pad')\
+            .construct(**{self._dim: ('ROWS', 'COLS')})

--- a/granule_ingester/granule_ingester/preprocessors/Trajectory.py
+++ b/granule_ingester/granule_ingester/preprocessors/Trajectory.py
@@ -31,4 +31,4 @@ class Trajectory(GranulePreprocessor):
         window = ceil(sqrt(length))
 
         return input_dataset.coarsen(**{self._dim: window}, boundary='pad')\
-            .construct(**{self._dim: ('ROWS', 'COLS')})
+            .construct(**{self._dim: ('ROWS', 'COLS')}, keep_attrs=True)

--- a/granule_ingester/setup.py
+++ b/granule_ingester/setup.py
@@ -40,7 +40,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests", "scripts"]),
     test_suite="tests",
     platforms='any',
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 1 - Pre-Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
SDAP-477: Added a preprocessor to reshape datasets wherein the data_vars are 1 dimensional arrays as opposed to 2 dimensional arrays

Specified in the collection config:
```yaml
preprocess:
  - name: trajectory
  dimension: xyz # <--- 1D dimension name
```

NOTE: The processed result will have its dimensions named to `ROWS` and `COLS`, so make slicer entries accordingly:
```yaml
slices:
  ROWS: 15
  COLS: 15
```

SDAP-478: I've encountered [some datasets](https://podaac.jpl.nasa.gov/announcements/2023-06-28-SWOT-L2-Nadir-Altimeter-and-Advanced-Microwave-Radiometer-Dataset-Release) wherein all the data variables are stored in a subgroup (not root group). Xarray does not open these groups unless specified (opens root by default) so we need a way to have the user specify (in the collection config) which group they want. If unspecified it defaults to root.

```yaml
- id: dataset
  path: <some path>
  group: subgroup
  ...
```

Currently, this allows focus on ONLY ONE subgroup, if the data exists across different groups, something else must be done.