### PR TITLE
Bring next release candidate up to date w/ dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- SDAP-488: Workaround to build issue on Apple Silicon (M1/M2). GI image build installs nexusproto through PyPI instead of building from source. A build arg `BUILD_NEXUSPROTO` was defined to allow building from source if desired/
 ### Security
 
 ## [1.1.0] - 2023-04-26

--- a/granule_ingester/docker/Dockerfile
+++ b/granule_ingester/docker/Dockerfile
@@ -30,6 +30,10 @@ COPY granule_ingester/conda-requirements.txt /sdap/conda-requirements.txt
 COPY granule_ingester/docker/install_nexusproto.sh /install_nexusproto.sh
 COPY granule_ingester/docker/entrypoint.sh /entrypoint.sh
 
+ARG BUILD_NEXUSPROTO
+ARG APACHE_NEXUSPROTO=https://github.com/apache/incubator-sdap-nexusproto.git
+ARG APACHE_NEXUSPROTO_BRANCH=master
+
 RUN ./install_nexusproto.sh
 RUN cd /common && python setup.py install
 RUN cd /sdap && python setup.py install

--- a/granule_ingester/docker/install_nexusproto.sh
+++ b/granule_ingester/docker/install_nexusproto.sh
@@ -15,21 +15,27 @@
 
 set -e
 
-APACHE_NEXUSPROTO="https://github.com/apache/incubator-sdap-nexusproto.git"
-MASTER="master"
+if [ ! -z ${BUILD_NEXUSPROTO+x} ]; then
+  echo 'Building nexusproto from source...'
 
-GIT_REPO=${1:-$APACHE_NEXUSPROTO}
-GIT_BRANCH=${2:-$MASTER}
+  APACHE_NEXUSPROTO="https://github.com/apache/incubator-sdap-nexusproto.git"
+  MASTER="master"
 
-mkdir nexusproto
-cd nexusproto
-git init
-git pull ${GIT_REPO} ${GIT_BRANCH}
+  GIT_REPO=${1:-$APACHE_NEXUSPROTO}
+  GIT_BRANCH=${2:-$MASTER}
 
-./gradlew pythonInstall --info
+  mkdir nexusproto
+  pushd nexusproto
+  git init
+  git pull ${GIT_REPO} ${GIT_BRANCH}
 
-./gradlew install --info
+  ./gradlew pythonInstall --info
 
-rm -rf /root/.gradle
-cd ..
-rm -rf nexusproto
+  ./gradlew install --info
+
+  rm -rf /root/.gradle
+  popd
+  rm -rf nexusproto
+else
+  pip install nexusproto
+fi


### PR DESCRIPTION
- SDAP-488: Workaround to build issue on Apple Silicon (M1/M2). GI image build installs nexusproto through PyPI instead of building from source. A build arg `BUILD_NEXUSPROTO` was defined to allow building from source if desired/